### PR TITLE
Handle deactivated priorities properly

### DIFF
--- a/src/pd.ts
+++ b/src/pd.ts
@@ -9,7 +9,7 @@ export class Result<T> {
 
   public error!: string
 
-  private fullError: any
+  public fullError: any
 
   private _value!: T
 
@@ -223,6 +223,34 @@ export async function me(token: string): Promise<Result<any>> {
   }
   const r = await request(token, '/users/me')
   return r
+}
+
+export async function getPrioritiesMapBy(token: string, attr: string): Promise<Result<any>> {
+  if (!isValidToken(token)) {
+    return Result.fail<any>(`Invalid token '${token}`)
+  }
+  const r = await fetch(token, '/priorities')
+  if (r.isFailure) {
+    if (r.fullError && r.fullError.response.status === 404) {
+      // priorities are disabled - return empty map
+      return Result.ok<any>({})
+    }
+    return r
+  }
+  const priorities = r.getValue()
+  const priorities_map: Record<string, any> = {}
+  for (const priority of priorities) {
+    priorities_map[priority[attr]] = priority
+  }
+  return Result.ok(priorities_map)
+}
+
+export async function getPrioritiesMapByName(token: string): Promise<Result<any>> {
+  return getPrioritiesMapBy(token, 'name')
+}
+
+export async function getPrioritiesMapByID(token: string): Promise<Result<any>> {
+  return getPrioritiesMapBy(token, 'id')
 }
 
 export function putBodyForSetAttributes(


### PR DESCRIPTION
Accounts can have priorities deactivated, in which case the /priorities
endpoint will return 404. See [this](https://community.pagerduty.com/forum/t/list-priorities-endpoint-returning-not-found/1387) for reference.