### PR TITLE
Update required node version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "typescript": "^3.3"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.0.0",
+    "npm": ">=6.0.0"
   },
   "files": [
     "/bin",


### PR DESCRIPTION
Force error during `npm` installation by adding `engine-strict=true` to `.npmrc`