### PR TITLE
Increasing the allowed node version range to 16 or greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "^4.6.4"
   },
   "engines": {
-    "node": "^16",
+    "node": ">=16",
     "npm": ">=6.0.0"
   },
   "files": [


### PR DESCRIPTION
I use this CLI regularly on Node 18 and it gives me a warning while installing even though the CLI works:

```npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'pagerduty-cli@0.1.15',
npm WARN EBADENGINE   required: { node: '^16', npm: '>=6.0.0' },
npm WARN EBADENGINE   current: { node: 'v18.6.0', npm: '8.13.2' }
npm WARN EBADENGINE }```

This PR updates the node version to be as permissive as the NPM version and support Node 16 or greater.